### PR TITLE
Fix gzip handling for pubmed_parser

### DIFF
--- a/pubmedflow/utils.py
+++ b/pubmedflow/utils.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 import io
 import uuid
 import glob
+import gzip
 
 from pdfminer3.layout import LAParams
 from pdfminer3.pdfpage import PDFPage
@@ -310,9 +311,8 @@ def fetch(self, query,
             fetch_r = requests.post(payload, verify=False)
             pre_name = f'{self.raw_abs_path}/pubmed_batch_{u_id}_{str(i)}_to_{str(i+all_rec)}.xml'
 
-            f = open(pre_name, 'wb')
-            f.write(fetch_r.content)
-            f.close()
+            with gzip.open(pre_name, 'wb') as f:
+                f.write(fetch_r.content)
 
             meta_data['uid'] = u_id
             meta_data['query'] = query

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+beautifulsoup4==4.14.3
+eutils==0.6.1
+metapub==0.7.4
+numpy==2.4.4
+pandas==3.0.2
+pdfminer3==2018.12.3.0
+pubmed_parser==0.5.1
+scidownl==1.0.2
+setuptools==82.0.1
+tqdm==4.67.3


### PR DESCRIPTION
## Fix: Handle gzipped XML responses from PubMed API

### Changes
- In `pubmedflow/utils.py`:
  - Added `import gzip`
  - Replaced plain file write with `gzip.open` when saving fetched XML batches
- Added `requirements.txt`

### Reason
`pubmed_parser` [is returning](https://github.com/titipata/pubmed_parser/commit/c6e45c7c722c1f543981b3454a370851273ecfc3#diff-d06bc41696c29dd31b0b108f73f1b08e459fe41971228378239e561a3063d43b) gzipped content from the NCBI E-utilities API. Saving the response with `gzip.open` ensures the `.xml` files are correctly written and readable by downstream parsing functions.